### PR TITLE
Dynamically set CMAKE_OSX_SYSROOT to the correct version

### DIFF
--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -46,7 +46,7 @@ DIR_BUILD_LIB                   = $(DIR_BUILD)lib/linux/
 CMAKE_FLAGS                     =
 else
 DIR_BUILD_LIB                   = $(DIR_BUILD)lib/osx/
-CMAKE_FLAGS                     = -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 -DCMAKE_CXX_FLAGS="-stdlib=libc++"
+CMAKE_FLAGS                     = -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 -DCMAKE_CXX_FLAGS="-stdlib=libc++"
 endif
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fix resolves an issue if cmake falls out-of-date with the OSX SDK version. If the OSX SDK included with Xcode does not match that expected by cmake then builds will fail. Explicitly setting CMAKE_OSX_SYSROOT to the current SDK resolves this.